### PR TITLE
don’t publish unnecessary files to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,5 +90,9 @@
       "it",
       "expect"
     ]
-  }
+  },
+  "files": [
+    "lib",
+    "with-defaults.js"
+  ]
 }


### PR DESCRIPTION
follow up for https://github.com/octokit/rest.js/issues/824