### PR TITLE
Bump max bundle size 3kb → 3.5kb

### DIFF
--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
   "bundlesize": [
     {
       "path": "./dist/octokit-endpoint.min.js.gz",
-      "maxSize": "3KB"
+      "maxSize": "3.5KB"
     }
   ],
   "release": {


### PR DESCRIPTION
I don’t know what exactly increased the bundle size but it wasn’t endpoint.js code, and I don’t have the time to look into it now

closes #26 