### PR TITLE
`options.mediaType.format` and `options.mediaType.previews`

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,28 @@ axios(options)
   </tr>
   <tr>
     <th align=left>
+      <code>options.mediaType.format</code>
+    </th>
+    <td>
+      String
+    </td>
+    <td>
+      Media type param, such as <code>raw</code>, <code>diff</code>, or <code>text+json</code>. See <a href="https://developer.github.com/v3/media/">Media Types</a>. Setting <code>options.mediaType.format</code> will amend the <code>headers.accept</code> value.
+    </td>
+  </tr>
+  <tr>
+    <th align=left>
+      <code>options.mediaType.previews</code>
+    </th>
+    <td>
+      Array of Strings
+    </td>
+    <td>
+      Name of previews, such as <code>mercy</code>, <code>symmetra</code>, or <code>scarlet-witch</code>. See <a href="https://developer.github.com/v3/previews/">API Previews</a>. If <code>options.mediaType.previews</code> was set as default, the new previews will be merged into the default ones. Setting <code>options.mediaType.previews</code> will amend the <code>headers.accept</code> value. <code>options.mediaType.previews</code> will be merged with an existing array set using <code>.defaults()</code>.
+    </td>
+  </tr>
+  <tr>
+    <th align=left>
       <code>options.method</code>
     </th>
     <td>

--- a/lib/defaults.js
+++ b/lib/defaults.js
@@ -9,5 +9,9 @@ module.exports = {
   headers: {
     accept: 'application/vnd.github.v3+json',
     'user-agent': userAgent
+  },
+  mediaType: {
+    format: '',
+    previews: []
   }
 }

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -18,5 +18,11 @@ function defaultOptions (defaults, route, options) {
 
   options = merge.all([defaults, options].filter(Boolean), { isMergeableObject: isPlainObject })
 
+  // mediaType.previews arrays are merged, instead of overwritten
+  if (defaults && defaults.mediaType.previews.length) {
+    options.mediaType.previews = defaults.mediaType.previews.filter(preview => !options.mediaType.previews.includes(preview))
+      .concat(options.mediaType.previews)
+  }
+
   return options
 }

--- a/lib/parse.js
+++ b/lib/parse.js
@@ -13,7 +13,7 @@ function toRequestOptions (options) {
   let url = options.url.replace(/:([a-z]\w+)/g, '{+$1}')
   let headers = options.headers
   let body
-  let parameters = omit(options, ['method', 'baseUrl', 'url', 'headers', 'request'])
+  let parameters = omit(options, ['method', 'baseUrl', 'url', 'headers', 'request', 'mediaType'])
 
   // extract variable names from URL to calculate remaining variables later
   const urlVariableNames = extractUrlVariableNames(url)
@@ -26,6 +26,17 @@ function toRequestOptions (options) {
 
   const omittedParameters = Object.keys(options).filter((option) => urlVariableNames.includes(option)).concat('baseUrl')
   const remainingParameters = omit(parameters, omittedParameters)
+
+  if (options.mediaType.format) {
+    // e.g. application/vnd.github.v3+json => application/vnd.github.v3.raw
+    headers.accept = headers.accept.replace(/application\/vnd(\.\w+)(\.v3)?(\.\w+)?(\+json)?$/, `application/vnd$1$2.${options.mediaType.format}`)
+  }
+
+  if (options.mediaType.previews.length) {
+    headers.accept = options.mediaType.previews.map(preview => {
+      return headers.accept.replace(/application\/vnd(\.\w+)(\.v3)?(\.\w+)?(\+json)?$/, `application/vnd.${preview}-preview$3$4`)
+    }).join(',')
+  }
 
   // for GET/HEAD requests, set URL query parameters from remaining parameters
   // for PATCH/POST/PUT/DELETE requests, set request body from remaining parameters

--- a/test/defaults-test.js
+++ b/test/defaults-test.js
@@ -70,7 +70,7 @@ describe('endpoint.defaults()', () => {
     expect(myEndpoint.DEFAULTS.baseUrl).to.equal('https://github-enterprise.acme-inc.com/api/v3')
   })
 
-  it('.defaults() merges options but does not yet parse ', () => {
+  it('.defaults() merges options but does not yet parse', () => {
     const myEndpoint = endpoint.defaults({
       url: '/orgs/:org',
       org: 'test1'
@@ -83,5 +83,39 @@ describe('endpoint.defaults()', () => {
     })
     expect(myEndpoint2.DEFAULTS.url).to.equal('/orgs/:org')
     expect(myEndpoint2.DEFAULTS.org).to.equal('test2')
+  })
+
+  it('.defaults() sets mediatType.format', () => {
+    const myEndpoint = endpoint.defaults({
+      mediaType: {
+        format: 'raw'
+      }
+    })
+    expect(myEndpoint.DEFAULTS.mediaType).to.deep.equal({
+      format: 'raw',
+      previews: []
+    })
+  })
+
+  it('.defaults() merges mediatType.previews', () => {
+    const myEndpoint = endpoint.defaults({
+      mediaType: {
+        previews: ['foo']
+      }
+    })
+    const myEndpoint2 = myEndpoint.defaults({
+      mediaType: {
+        previews: ['bar']
+      }
+    })
+
+    expect(myEndpoint.DEFAULTS.mediaType).to.deep.equal({
+      format: '',
+      previews: ['foo']
+    })
+    expect(myEndpoint2.DEFAULTS.mediaType).to.deep.equal({
+      format: '',
+      previews: ['foo', 'bar']
+    })
   })
 })

--- a/test/endpoint-test.js
+++ b/test/endpoint-test.js
@@ -268,4 +268,71 @@ describe('endpoint()', () => {
     expect(endpoint('/').method).to.equal('GET')
     expect(endpoint('https://github.acme-inc/api/v3/').url).to.equal('https://github.acme-inc/api/v3/')
   })
+
+  it('options.mediaType.format', () => {
+    const options = endpoint({
+      method: 'get',
+      url: '/repos/:owner/:repo/issues/:number',
+      mediaType: {
+        format: 'raw'
+      },
+      owner: 'octokit',
+      repo: 'endpoint.js',
+      number: 123
+    })
+
+    expect(options).to.deep.equal({
+      method: 'GET',
+      url: 'https://api.github.com/repos/octokit/endpoint.js/issues/123',
+      headers: {
+        accept: 'application/vnd.github.v3.raw',
+        'user-agent': userAgent
+      }
+    })
+  })
+
+  it('options.mediaType.previews', () => {
+    const options = endpoint({
+      method: 'get',
+      url: '/repos/:owner/:repo/issues/:number',
+      mediaType: {
+        previews: ['symmetra']
+      },
+      owner: 'octokit',
+      repo: 'endpoint.js',
+      number: 123
+    })
+
+    expect(options).to.deep.equal({
+      method: 'GET',
+      url: 'https://api.github.com/repos/octokit/endpoint.js/issues/123',
+      headers: {
+        accept: 'application/vnd.symmetra-preview+json',
+        'user-agent': userAgent
+      }
+    })
+  })
+
+  it('options.mediaType.format + options.mediaType.previews', () => {
+    const options = endpoint({
+      method: 'get',
+      url: '/repos/:owner/:repo/issues/:number',
+      mediaType: {
+        format: 'raw',
+        previews: ['symmetra']
+      },
+      owner: 'octokit',
+      repo: 'endpoint.js',
+      number: 123
+    })
+
+    expect(options).to.deep.equal({
+      method: 'GET',
+      url: 'https://api.github.com/repos/octokit/endpoint.js/issues/123',
+      headers: {
+        accept: 'application/vnd.symmetra-preview.raw',
+        'user-agent': userAgent
+      }
+    })
+  })
 })

--- a/test/merge-test.js
+++ b/test/merge-test.js
@@ -31,6 +31,10 @@ describe('endpoint.merge()', () => {
 
     expect(options).to.deep.equal({
       baseUrl: 'https://github-enterprise.acme-inc.com/api/v3',
+      mediaType: {
+        format: '',
+        previews: []
+      },
       method: 'GET',
       url: '/orgs/:org/repos',
       headers: {
@@ -61,6 +65,10 @@ describe('endpoint.merge()', () => {
 
     expect(options).to.deep.equal({
       baseUrl: 'https://github-enterprise.acme-inc.com/api/v3',
+      mediaType: {
+        format: '',
+        previews: []
+      },
       method: 'GET',
       url: '/orgs/:org/repos',
       headers: {
@@ -76,6 +84,10 @@ describe('endpoint.merge()', () => {
     const options = endpoint.merge()
     expect(options).to.deep.equal({
       baseUrl: 'https://api.github.com',
+      mediaType: {
+        format: '',
+        previews: []
+      },
       method: 'GET',
       headers: {
         accept: 'application/vnd.github.v3+json',


### PR DESCRIPTION
closes #33

-----
[View rendered README.md](https://github.com/octokit/endpoint.js/blob/33/mediatype-parameter/README.md)