### PR TITLE
build(typescript): Fix directory structure and enable project compiltion

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -12,8 +12,8 @@
     // "sourceMap": true,                     /* Generates corresponding '.map' file. */
     // "outFile": "./",                       /* Concatenate and emit output to single file. */
     "outDir": "lib",                          /* Redirect output structure to the directory. */
-    // "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
-    // "composite": true,                     /* Enable project compilation */
+    "rootDir": "./src",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    "composite": true,                        /* Enable project compilation */
     // "removeComments": true,                /* Do not emit comments to output. */
     // "noEmit": true,                        /* Do not emit outputs. */
     // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */


### PR DESCRIPTION
This way the paths set for the `main` and `types` property in `package.json` exist and are not in a src subdirectory.
By enabling the `composite` flag, compile times will be faster and will only re-compile changed files, which will save time