### PR TITLE
fix(merge.ts): clone route argument to avoid mutation

### DIFF
--- a/src/merge.ts
+++ b/src/merge.ts
@@ -11,7 +11,7 @@ export function merge(
     let [method, url] = route.split(" ");
     options = Object.assign(url ? { method, url } : { url: method }, options);
   } else {
-    options = route || {};
+    options = Object.assign({}, route);
   }
 
   // lowercase header names before merging with defaults to avoid duplicates

--- a/test/merge.test.ts
+++ b/test/merge.test.ts
@@ -90,4 +90,38 @@ describe("endpoint.merge()", () => {
       }
     });
   });
+
+  it("does not mutate the route param", () => {
+    const route = {
+      owner: "octokit",
+      repo: "endpoint.js"
+    };
+
+    endpoint.merge(route);
+
+    expect(route).toEqual({
+      owner: "octokit",
+      repo: "endpoint.js"
+    });
+  });
+
+  it("does not mutate/lowercase the headers field of route", () => {
+    const route = {
+      owner: "octokit",
+      repo: "endpoint.js",
+      headers: {
+        "Content-Type": "application/json"
+      }
+    };
+
+    endpoint.merge(route);
+
+    expect(route).toEqual({
+      owner: "octokit",
+      repo: "endpoint.js",
+      headers: {
+        "Content-Type": "application/json"
+      }
+    });
+  });
 });

--- a/test/merge.test.ts
+++ b/test/merge.test.ts
@@ -99,7 +99,7 @@ describe("endpoint.merge()", () => {
 
     endpoint.merge(route);
 
-    expect(route).toEqual({
+    expect(route).toStrictEqual({
       owner: "octokit",
       repo: "endpoint.js"
     });
@@ -116,7 +116,7 @@ describe("endpoint.merge()", () => {
 
     endpoint.merge(route);
 
-    expect(route).toEqual({
+    expect(route).toStrictEqual({
       owner: "octokit",
       repo: "endpoint.js",
       headers: {


### PR DESCRIPTION
This uses `Object.assign` to clone the `route` argument before assigning
it to the `options` variable.

Before this change a headers field was being set on the `options`
variable, which was the same reference. Another effect of this change is
that the headers field on the `route` argument would be mutated to be
lowercase. Now the lowercase operation happens on the cloned value
instead of mutating the argument passed in to the function.

Closes https://github.com/octokit/rest.js/issues/1394