### PR TITLE
Fix Readme Table of Content Anchor Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   - [endpoint()](#endpointroute-options-or-endpointoptions)
   - [endpoint.defaults()](#endpointdefaults)
   - [endpoint.DEFAULTS](#endpointdefaults-1)
-  - [endpoint.merge()](#endpointmergeroute-options-or-endpointmergeoption)
+  - [endpoint.merge()](#endpointmergeroute-options-or-endpointmergeoptions)
   - [endpoint.parse()](#endpointparse)
 - [Special cases](#special-cases)
   - [The `data` parameter – set request body directly](#the-data-parameter--set-request-body-directly)

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@
 
 - [Usage](#usage)
 - [API](#api)
-  - [endpoint()](#endpoint)
+  - [endpoint()](#endpointroute-options-or-endpointoptions)
   - [endpoint.defaults()](#endpointdefaults)
-  - [endpoint.DEFAULTS](#endpointdefaults)
-  - [endpoint.merge()](#endpointmerge)
+  - [endpoint.DEFAULTS](#endpointdefaults-1)
+  - [endpoint.merge()](#endpointmergeroute-options-or-endpointmergeoption)
   - [endpoint.parse()](#endpointparse)
 - [Special cases](#special-cases)
-  - [The `data` parameter – set request body directly](#the-data-parameter-%E2%80%93-set-request-body-directly)
+  - [The `data` parameter – set request body directly](#the-data-parameter--set-request-body-directly)
   - [Set parameters for both the URL/query and the request body](#set-parameters-for-both-the-urlquery-and-the-request-body)
 - [LICENSE](#license)
 


### PR DESCRIPTION
Changes
- fixing table of content anchor links (several links were incorrect)

-----
[View rendered README.md](https://github.com/kevo1ution/endpoint.js/blob/Fix.Readme/README.md)