### PR TITLE
Filter out undefined query parameters and headers

### DIFF
--- a/src/merge.ts
+++ b/src/merge.ts
@@ -20,8 +20,8 @@ export function merge(
   options.headers = lowercaseKeys(options.headers);
 
   // remove properties with undefined values before merging
-  options.headers = removeUndefinedProperties(options.headers);
-  options = removeUndefinedProperties(options);
+  removeUndefinedProperties(options);
+  removeUndefinedProperties(options.headers);
 
   const mergedOptions = mergeDeep(defaults || {}, options) as EndpointDefaults;
 

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -2,6 +2,7 @@ import { EndpointDefaults, RequestParameters, Route } from "@octokit/types";
 
 import { lowercaseKeys } from "./util/lowercase-keys";
 import { mergeDeep } from "./util/merge-deep";
+import { removeUndefinedProperties } from "./util/remove-undefined-properties";
 
 export function merge(
   defaults: EndpointDefaults | null,
@@ -17,6 +18,10 @@ export function merge(
 
   // lowercase header names before merging with defaults to avoid duplicates
   options.headers = lowercaseKeys(options.headers);
+
+  // remove properties with undefined values before merging
+  options.headers = removeUndefinedProperties(options.headers);
+  options = removeUndefinedProperties(options);
 
   const mergedOptions = mergeDeep(defaults || {}, options) as EndpointDefaults;
 

--- a/src/util/add-query-parameters.ts
+++ b/src/util/add-query-parameters.ts
@@ -3,7 +3,9 @@ export function addQueryParameters(
   parameters: { [x: string]: string | undefined; q?: string }
 ) {
   const separator = /\?/.test(url) ? "&" : "?";
-  const names = Object.keys(parameters);
+  const names = Object.keys(parameters).filter(
+    (name) => parameters[name] !== undefined
+  );
 
   if (names.length === 0) {
     return url;

--- a/src/util/add-query-parameters.ts
+++ b/src/util/add-query-parameters.ts
@@ -3,9 +3,7 @@ export function addQueryParameters(
   parameters: { [x: string]: string | undefined; q?: string }
 ) {
   const separator = /\?/.test(url) ? "&" : "?";
-  const names = Object.keys(parameters).filter(
-    (name) => parameters[name] !== undefined
-  );
+  const names = Object.keys(parameters);
 
   if (names.length === 0) {
     return url;

--- a/src/util/remove-undefined-properties.ts
+++ b/src/util/remove-undefined-properties.ts
@@ -1,9 +1,8 @@
 export function removeUndefinedProperties(obj: any): any {
-  const copy = Object.assign({}, obj);
-  for (const key in copy) {
-    if (copy[key] === undefined) {
-      delete copy[key];
+  for (const key in obj) {
+    if (obj[key] === undefined) {
+      delete obj[key];
     }
   }
-  return copy;
+  return obj;
 }

--- a/src/util/remove-undefined-properties.ts
+++ b/src/util/remove-undefined-properties.ts
@@ -1,0 +1,9 @@
+export function removeUndefinedProperties(obj: any): any {
+  const copy = Object.assign({}, obj);
+  for (const key in copy) {
+    if (copy[key] === undefined) {
+      delete copy[key];
+    }
+  }
+  return copy;
+}

--- a/test/endpoint.test.ts
+++ b/test/endpoint.test.ts
@@ -427,4 +427,16 @@ describe("endpoint()", () => {
       },
     });
   });
+
+  it("Undefined header value", () => {
+    const options = endpoint({
+      method: "GET",
+      url: "/notifications",
+      headers: {
+        "if-modified-since": undefined,
+      },
+    });
+
+    expect(options).not.toHaveProperty("headers.if-modified-since");
+  });
 });

--- a/test/endpoint.test.ts
+++ b/test/endpoint.test.ts
@@ -410,4 +410,21 @@ describe("endpoint()", () => {
       },
     });
   });
+
+  it("Undefined query parameter", () => {
+    const options = endpoint({
+      method: "GET",
+      url: "/notifications",
+      before: undefined,
+    });
+
+    expect(options).toEqual({
+      method: "GET",
+      url: "https://api.github.com/notifications",
+      headers: {
+        accept: "application/vnd.github.v3+json",
+        "user-agent": userAgent,
+      },
+    });
+  });
 });


### PR DESCRIPTION
Fixes #206

I initially filtered out undefined query parameters in `add-query-parameters.ts`, but then I realized that undefined headers were also being erroneously included. To fix both of those I made it so that undefined values are removed from the options passed by the user before merging.