### PR TITLE
ci(test): use `test_matrix` and `test` jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,7 +8,7 @@ name: Test
       - opened
       - synchronize
 jobs:
-  test:
+  test_matrix:
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -24,4 +24,11 @@ jobs:
           node-version: "${{ matrix.node_version }}"
           cache: npm
       - run: npm ci
-      - run: npm run test
+      - run: npm run test --ignore-scripts # run lint only once
+  test:
+    runs-on: ubuntu-latest
+    needs: test_matrix
+    steps:
+      - uses: actions/checkout@2541b1294d2704b0964813337f33b291d3f8596b # tag=v3
+      - run: npm ci
+      - run: npm run lint


### PR DESCRIPTION
Follow up to #326
Add a `test_matrix` step and then a `test` step that depends on `test_matrix`, so that for branch protections we can require `test` independent of the Node versions we are using. 
