### PR TITLE
fix: fix support for Node.js v18's native `fetch` when making `DELETE` requests with no body

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -81,8 +81,6 @@ export function parse(options: EndpointDefaults): RequestOptions {
     } else {
       if (Object.keys(remainingParameters).length) {
         body = remainingParameters;
-      } else {
-        headers["content-length"] = 0;
       }
     }
   }

--- a/test/endpoint.test.ts
+++ b/test/endpoint.test.ts
@@ -144,7 +144,7 @@ describe("endpoint()", () => {
     });
   });
 
-  it("Put without request body", () => {
+  it("PUT without request body", () => {
     const options = endpoint("PUT /user/starred/{owner}/{repo}", {
       headers: {
         authorization: `token 0000000000000000000000000000000000000001`,
@@ -154,15 +154,71 @@ describe("endpoint()", () => {
     });
 
     expect(options).toEqual({
+      body: "",
       method: "PUT",
       url: "https://api.github.com/user/starred/octocat/hello-world",
       headers: {
         authorization: `token 0000000000000000000000000000000000000001`,
         accept: "application/vnd.github.v3+json",
-        "content-length": 0,
         "user-agent": userAgent,
       },
+    });
+  });
+
+  it("DELETE without request body", () => {
+    const options = endpoint("DELETE /user/following/{username}", {
+      headers: {
+        authorization: `token 0000000000000000000000000000000000000001`,
+      },
+      username: "octocat",
+    });
+
+    expect(options).toEqual({
+      method: "DELETE",
+      url: "https://api.github.com/user/following/octocat",
+      headers: {
+        authorization: `token 0000000000000000000000000000000000000001`,
+        accept: "application/vnd.github.v3+json",
+        "user-agent": userAgent,
+      },
+    });
+  });
+
+  it("POST without request body", () => {
+    const options = endpoint("POST /widgets", {
+      headers: {
+        authorization: `token 0000000000000000000000000000000000000001`,
+      },
+    });
+
+    expect(options).toEqual({
+      method: "POST",
+      url: "https://api.github.com/widgets",
+      headers: {
+        authorization: `token 0000000000000000000000000000000000000001`,
+        accept: "application/vnd.github.v3+json",
+        "user-agent": userAgent,
+      },
+    });
+  });
+
+  it("PATCH without request body", () => {
+    const options = endpoint("PATCH /widgets/{id}", {
+      headers: {
+        authorization: `token 0000000000000000000000000000000000000001`,
+      },
+      id: "my-widget",
+    });
+
+    expect(options).toEqual({
       body: "",
+      method: "PATCH",
+      url: "https://api.github.com/widgets/my-widget",
+      headers: {
+        authorization: `token 0000000000000000000000000000000000000001`,
+        accept: "application/vnd.github.v3+json",
+        "user-agent": userAgent,
+      },
     });
   });
 


### PR DESCRIPTION
Currently, `DELETE` requests without a body don't work on the latest Node.js version, v18, because we try to set `content-length: 0` which is not allowed by the native `fetch` implementation which is included in Node. It throws an error with the `UND_ERR_REQ_CONTENT_LENGTH_MISMATCH` code.

This stops manually setting that `content-length: 0` header for `DELETE` requests.

I've tested this against the GitHub API with Node.js v18and v17, and both work as expected, with the GitHub API also accepting the request.

As part of this PR, I've also added some new tests covering what happens with different HTTP methods.

Fixes https://github.com/octokit/request.js/issues/506.