### PR TITLE
fix: type cast empty array to fix a typescript error

### DIFF
--- a/src/parse.ts
+++ b/src/parse.ts
@@ -58,7 +58,7 @@ export function parse(options: EndpointDefaults): RequestOptions {
 
     if (options.mediaType.previews.length) {
       const previewsFromAcceptHeader =
-        headers.accept.match(/[\w-]+(?=-preview)/g) || [];
+        headers.accept.match(/[\w-]+(?=-preview)/g) || [] as string[];
       headers.accept = previewsFromAcceptHeader
         .concat(options.mediaType.previews)
         .map((preview) => {

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -58,7 +58,7 @@ export function parse(options: EndpointDefaults): RequestOptions {
 
     if (options.mediaType.previews.length) {
       const previewsFromAcceptHeader =
-        headers.accept.match(/[\w-]+(?=-preview)/g) || [] as string[];
+        headers.accept.match(/[\w-]+(?=-preview)/g) || ([] as string[]);
       headers.accept = previewsFromAcceptHeader
         .concat(options.mediaType.previews)
         .map((preview) => {


### PR DESCRIPTION
See #379, the tests are failing due to an error with typescript 

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* The array was typed as `never[]`

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* The array is now correctly types


### Other information
<!-- Any other information that is important to this PR  -->

* 

----

## Additional info

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:  

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. --> 
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. --> 

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`
- Feature/model/API additions: `Type: Feature`
- Updates to docs or samples: `Type: Documentation`
- Dependencies/code cleanup: `Type: Maintenance`

----

