### PR TITLE
docs: replace references to Skypack CDN with esm.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,11 +32,11 @@
 <tr><th>
 Browsers
 </th><td width=100%>
-Load <code>@octokit/endpoint</code> directly from <a href="https://cdn.skypack.dev">cdn.skypack.dev</a>
+Load <code>@octokit/endpoint</code> directly from <a href="https://esm.sh">esm.sh</a>
 
 ```html
 <script type="module">
-  import { endpoint } from "https://cdn.skypack.dev/@octokit/endpoint";
+  import { endpoint } from "https://esm.sh/@octokit/endpoint";
 </script>
 ```
 


### PR DESCRIPTION
The Skypack CDN is no longer maintained, so we should remove references to it.