### PR TITLE
fix: account for possibility that `mergedOptions.mediaType.previews` may be undefined

### DIFF
--- a/src/merge.ts
+++ b/src/merge.ts
@@ -39,9 +39,9 @@ export function merge(
         .concat(mergedOptions.mediaType.previews!);
     }
 
-    mergedOptions.mediaType.previews = mergedOptions.mediaType.previews!.map(
-      (preview: string) => preview.replace(/-preview/, "")
-    );
+    mergedOptions.mediaType.previews = (
+      mergedOptions.mediaType.previews! || ([] as string[])
+    ).map((preview: string) => preview.replace(/-preview/, ""));
   }
 
   return mergedOptions;

--- a/test/endpoint.test.ts
+++ b/test/endpoint.test.ts
@@ -340,6 +340,22 @@ describe("endpoint()", () => {
     );
   });
 
+  it("options.mediaType.previews is undefined", () => {
+    const options = endpoint({
+      method: "POST",
+      url: "/graphql",
+    });
+
+    expect(options).toEqual({
+      method: "POST",
+      url: "https://api.github.com/graphql",
+      headers: {
+        accept: "application/vnd.github.v3+json",
+        "user-agent": userAgent,
+      },
+    });
+  });
+
   it("options.mediaType.format", () => {
     const options = endpoint({
       method: "GET",


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->


<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

## Behavior

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* Tests would fail in the beta version of `@octokit/graphql` because `mergedOptions.mediaType.previews` may be undefined

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* If `mergedOptions.mediaType.previews` is undefined, use an empty array for the call to `Array#map()`


### Other information
<!-- Any other information that is important to this PR  -->

* Tests are now passing downstream with this fix

----

## Additional info

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features) — Tests in `@octokit/graphql` beta pass with this change
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)
- [x] Added the appropriate label for the given change

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/main/community/breaking_changes.md) to help!

- [ ] Yes (Please add the `Type: Breaking change` label)
- [x] No

If `Yes`, what's the impact:

* N/A


### Pull request type

<!-- Please do not submit updates to dependencies unless it fixes an issue. -->
<!-- Please try to limit your pull request to one type, submit multiple pull requests if needed. -->

Please add the corresponding label for change this PR introduces:
- Bugfix: `Type: Bug`

----

