### PR TITLE
fix: remove trailing slash for invalid URL

### DIFF
--- a/src/util/url-template.ts
+++ b/src/util/url-template.ts
@@ -156,7 +156,7 @@ export function parseUrl(template: string) {
 function expand(template: string, context: object): string {
   var operators = ["+", "#", ".", "/", ";", "?", "&"];
 
-  return template.replace(
+  template = template.replace(
     /\{([^\{\}]+)\}|([^\{\}]+)/g,
     function (_, expression, literal) {
       if (expression) {
@@ -190,4 +190,10 @@ function expand(template: string, context: object): string {
       }
     },
   );
+
+  if (template === "/") {
+    return template;
+  } else {
+    return template.replace(/\/$/, "");
+  }
 }

--- a/test/endpoint.test.ts
+++ b/test/endpoint.test.ts
@@ -552,13 +552,13 @@ describe("endpoint()", () => {
     const options2 = endpoint("GET /repos/{owner}/{repo}/contents/{path}", {
       owner: "owner",
       repo: "repo",
-      path: "heads/",
+      path: "my-folder/",
       ref: "feature/branch",
     });
 
     expect(options2).toEqual({
       method: "GET",
-      url: "https://api.github.com/repos/owner/repo/contents/heads%2F?ref=feature%2Fbranch",
+      url: "https://api.github.com/repos/owner/repo/contents/my-folder%2F?ref=feature%2Fbranch",
       headers: {
         accept: "application/vnd.github.v3+json",
         "user-agent": userAgent,

--- a/test/endpoint.test.ts
+++ b/test/endpoint.test.ts
@@ -530,6 +530,42 @@ describe("endpoint()", () => {
     });
   });
 
+  it("Trailing slash in URL in expression is encoded", () => {
+    const options1 = endpoint(
+      "GET /repos/{owner}/{repo}/git/matching-refs/{ref}",
+      {
+        owner: "owner",
+        repo: "repo",
+        ref: "heads/",
+      },
+    );
+
+    expect(options1).toEqual({
+      method: "GET",
+      url: "https://api.github.com/repos/owner/repo/git/matching-refs/heads%2F",
+      headers: {
+        accept: "application/vnd.github.v3+json",
+        "user-agent": userAgent,
+      },
+    });
+
+    const options2 = endpoint("GET /repos/{owner}/{repo}/contents/{path}", {
+      owner: "owner",
+      repo: "repo",
+      path: "heads/",
+      ref: "feature/branch",
+    });
+
+    expect(options2).toEqual({
+      method: "GET",
+      url: "https://api.github.com/repos/owner/repo/contents/heads%2F?ref=feature%2Fbranch",
+      headers: {
+        accept: "application/vnd.github.v3+json",
+        "user-agent": userAgent,
+      },
+    });
+  });
+
   it("Undefined header value", () => {
     const options = endpoint({
       method: "GET",

--- a/test/endpoint.test.ts
+++ b/test/endpoint.test.ts
@@ -336,7 +336,7 @@ describe("endpoint()", () => {
     expect(endpoint("/").url).toEqual("https://api.github.com/");
     expect(endpoint("/").method).toEqual("GET");
     expect(endpoint("https://github.acme-inc/api/v3/").url).toEqual(
-      "https://github.acme-inc/api/v3/",
+      "https://github.acme-inc/api/v3",
     );
   });
 
@@ -493,6 +493,36 @@ describe("endpoint()", () => {
     expect(options).toEqual({
       method: "GET",
       url: "https://api.github.com/notifications",
+      headers: {
+        accept: "application/vnd.github.v3+json",
+        "user-agent": userAgent,
+      },
+    });
+  });
+
+  it("Undefined placeholder value with no trailing slash in URL", () => {
+    const options1 = endpoint("GET /repos/{owner}/{repo}/branches/{branch}", {
+      owner: "owner",
+      repo: "repo",
+    });
+
+    expect(options1).toEqual({
+      method: "GET",
+      url: "https://api.github.com/repos/owner/repo/branches",
+      headers: {
+        accept: "application/vnd.github.v3+json",
+        "user-agent": userAgent,
+      },
+    });
+
+    const options2 = endpoint("GET /repos/{owner}/{repo}/branches{/branch}", {
+      owner: "owner",
+      repo: "repo",
+    });
+
+    expect(options2).toEqual({
+      method: "GET",
+      url: "https://api.github.com/repos/owner/repo/branches",
       headers: {
         accept: "application/vnd.github.v3+json",
         "user-agent": userAgent,


### PR DESCRIPTION
<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #395

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* remove trailing slashes from URL except expanded endpoint is `/`

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* if you specify url like `endpoint("https://github.acme-inc/api/v3/")`, it will cause to trailing slash removed.

### Pull request checklist
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

* if you specify url like `endpoint("https://github.acme-inc/api/v3/")`, it will cause to trailing slash removed.

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [x] Yes
- [ ] No

----

