### PR TITLE
refactor: use `node:` specifier imports and full relative import paths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
       "devDependencies": {
         "@octokit/tsconfig": "^2.0.0",
         "@types/jest": "^29.0.0",
+        "@types/node": "^20.10.0",
         "esbuild": "^0.19.0",
         "glob": "^10.2.7",
         "jest": "^29.0.0",
@@ -2242,10 +2243,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.3.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.3.1.tgz",
-      "integrity": "sha512-EhcH/wvidPy1WeML3TtYFGR83UzjxeWRen9V402T8aUGYsCHOmfoisV3ZSg03gAFIbLq8TnWOJ0f4cALtnSEUg==",
-      "dev": true
+      "version": "20.10.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.10.0.tgz",
+      "integrity": "sha512-D0WfRmU9TQ8I9PFx9Yc+EBHw+vSpIub4IDvQivcp26PtPrdMGAq5SDcpXEo/epqa/DXotVpekHiLNTg3iaKXBQ==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.1",
@@ -10706,9 +10710,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.1.3.tgz",
-      "integrity": "sha512-XH627E9vkeqhlZFQuL+UsyAXEnibT0kWR2FWONlr4sTjvxyJYnyefgrkyECLzM5NenmKzRAy2rR/OlYLA1HkZw==",
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.3.2.tgz",
+      "integrity": "sha512-6l+RyNy7oAHDfxC4FzSJcz9vnjTKxrLpDG5M2Vu4SHRVNg6xzqZp6LYSR9zjqQTu8DU/f5xwxUdADOkbrIX2gQ==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",
@@ -10730,6 +10734,12 @@
       "engines": {
         "node": ">=0.8.0"
       }
+    },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
     },
     "node_modules/unique-string": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "devDependencies": {
     "@octokit/tsconfig": "^2.0.0",
     "@types/jest": "^29.0.0",
+    "@types/node": "^20.10.0",
     "esbuild": "^0.19.0",
     "glob": "^10.2.7",
     "jest": "^29.0.0",
@@ -85,6 +86,9 @@
         "functions": 100,
         "lines": 100
       }
+    },
+    "moduleNameMapper": {
+      "^(.+)\\.jsx?$": "$1"
     }
   },
   "engines": {

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -1,7 +1,7 @@
 import { getUserAgent } from "universal-user-agent";
 import type { EndpointDefaults } from "@octokit/types";
 
-import { VERSION } from "./version";
+import { VERSION } from "./version.js";
 
 const userAgent = `octokit-endpoint.js/${VERSION} ${getUserAgent()}`;
 

--- a/src/endpoint-with-defaults.ts
+++ b/src/endpoint-with-defaults.ts
@@ -1,8 +1,8 @@
 import type { EndpointOptions, RequestParameters, Route } from "@octokit/types";
 
-import { DEFAULTS } from "./defaults";
-import { merge } from "./merge";
-import { parse } from "./parse";
+import { DEFAULTS } from "./defaults.js";
+import { merge } from "./merge.js";
+import { parse } from "./parse.js";
 
 export function endpointWithDefaults(
   defaults: typeof DEFAULTS,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,11 @@
-import { withDefaults } from "./with-defaults";
-import { DEFAULTS } from "./defaults";
+import { withDefaults } from "./with-defaults.js";
+import { DEFAULTS } from "./defaults.js";
 
 export const endpoint = withDefaults(null, DEFAULTS);
+
+fetch("https://api.github.com/users/octocat", {
+  headers: {
+    accept: "application/vnd.github.v3+json",
+  },
+  method: "GET",
+})

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,3 @@ import { withDefaults } from "./with-defaults.js";
 import { DEFAULTS } from "./defaults.js";
 
 export const endpoint = withDefaults(null, DEFAULTS);
-
-fetch("https://api.github.com/users/octocat", {
-  headers: {
-    accept: "application/vnd.github.v3+json",
-  },
-  method: "GET",
-})

--- a/src/merge.ts
+++ b/src/merge.ts
@@ -4,9 +4,9 @@ import type {
   Route,
 } from "@octokit/types";
 
-import { lowercaseKeys } from "./util/lowercase-keys";
-import { mergeDeep } from "./util/merge-deep";
-import { removeUndefinedProperties } from "./util/remove-undefined-properties";
+import { lowercaseKeys } from "./util/lowercase-keys.js";
+import { mergeDeep } from "./util/merge-deep.js";
+import { removeUndefinedProperties } from "./util/remove-undefined-properties.js";
 
 export function merge(
   defaults: EndpointDefaults | null,

--- a/src/parse.ts
+++ b/src/parse.ts
@@ -4,10 +4,10 @@ import type {
   RequestOptions,
 } from "@octokit/types";
 
-import { addQueryParameters } from "./util/add-query-parameters";
-import { extractUrlVariableNames } from "./util/extract-url-variable-names";
-import { omit } from "./util/omit";
-import { parseUrl } from "./util/url-template";
+import { addQueryParameters } from "./util/add-query-parameters.js";
+import { extractUrlVariableNames } from "./util/extract-url-variable-names.js";
+import { omit } from "./util/omit.js";
+import { parseUrl } from "./util/url-template.js";
 
 export function parse(options: EndpointDefaults): RequestOptions {
   // https://fetch.spec.whatwg.org/#methods

--- a/src/util/merge-deep.ts
+++ b/src/util/merge-deep.ts
@@ -1,4 +1,4 @@
-import { isPlainObject } from "./is-plain-object";
+import { isPlainObject } from "./is-plain-object.js";
 
 export function mergeDeep(defaults: any, options: any): object {
   const result = Object.assign({}, defaults);

--- a/src/with-defaults.ts
+++ b/src/with-defaults.ts
@@ -4,9 +4,9 @@ import type {
   EndpointDefaults,
 } from "@octokit/types";
 
-import { endpointWithDefaults } from "./endpoint-with-defaults";
-import { merge } from "./merge";
-import { parse } from "./parse";
+import { endpointWithDefaults } from "./endpoint-with-defaults.js";
+import { merge } from "./merge.js";
+import { parse } from "./parse.js";
 
 export function withDefaults(
   oldDefaults: EndpointDefaults | null,

--- a/test/defaults.test.ts
+++ b/test/defaults.test.ts
@@ -1,4 +1,4 @@
-import { endpoint } from "../src";
+import { endpoint } from "../src/index.js";
 
 describe("endpoint.defaults()", () => {
   it("is a function", () => {

--- a/test/endpoint.test.ts
+++ b/test/endpoint.test.ts
@@ -1,4 +1,4 @@
-import { Agent } from "http";
+import { Agent } from "node:http";
 
 import { getUserAgent } from "universal-user-agent";
 

--- a/test/endpoint.test.ts
+++ b/test/endpoint.test.ts
@@ -2,8 +2,8 @@ import { Agent } from "node:http";
 
 import { getUserAgent } from "universal-user-agent";
 
-import { endpoint } from "../src";
-import { VERSION } from "../src/version";
+import { endpoint } from "../src/index.ts";
+import { VERSION } from "../src/version.ts";
 
 const userAgent = `octokit-endpoint.js/${VERSION} ${getUserAgent()}`;
 

--- a/test/is-plaint-object.test.ts
+++ b/test/is-plaint-object.test.ts
@@ -1,4 +1,4 @@
-import { isPlainObject } from "../src/util/is-plain-object";
+import { isPlainObject } from "../src/util/is-plain-object.ts";
 
 describe("isPlainObject", () => {
   function Foo() {

--- a/test/merge.test.ts
+++ b/test/merge.test.ts
@@ -1,7 +1,7 @@
 import { getUserAgent } from "universal-user-agent";
 
-import { endpoint } from "../src";
-import { VERSION } from "../src/version";
+import { endpoint } from "../src/index.ts";
+import { VERSION } from "../src/version.ts";
 const userAgent = `octokit-endpoint.js/${VERSION} ${getUserAgent()}`;
 
 describe("endpoint.merge()", () => {

--- a/test/parse.test.ts
+++ b/test/parse.test.ts
@@ -1,6 +1,6 @@
 import type { EndpointOptions, EndpointDefaults } from "@octokit/types";
 
-import { endpoint } from "../src";
+import { endpoint } from "../src/index.ts";
 
 describe("endpoint.parse()", () => {
   it("is a function", () => {

--- a/test/tsconfig.test.json
+++ b/test/tsconfig.test.json
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "emitDeclarationOnly": false,
     "noEmit": true,
-    "verbatimModuleSyntax": false
+    "verbatimModuleSyntax": false,
+    "allowImportingTsExtensions": true
   },
   "include": ["src/**/*"]
 }


### PR DESCRIPTION
This PR replaces NodeJS internal module imports with `node:` specifier imports.