### PR TITLE
fix(performance): improve omit

### DIFF
--- a/src/util/omit.ts
+++ b/src/util/omit.ts
@@ -2,10 +2,13 @@ export function omit(
   object: { [key: string]: any },
   keysToOmit: string[],
 ): { [key: string]: any } {
-  return Object.keys(object)
-    .filter((option) => !keysToOmit.includes(option))
-    .reduce((obj: { [key: string]: any }, key) => {
-      obj[key] = object[key];
-      return obj;
-    }, {});
+  const result: { [key: string]: any } = { __proto__: null };
+
+  for (const key of Object.keys(object)) {
+    if (keysToOmit.indexOf(key) === -1) {
+      result[key] = object[key];
+    }
+  }
+
+  return result;
 }


### PR DESCRIPTION
This PR is improving the omit function performance by avoiding the array utility functions. It also initializes the object with __proto__: null to be more resilient to potential prototype pollutions. __proto__: null puts the object into dictionary mode which is slightly less performant. So probably the performance improvements of avoiding the array utility function is eaten by the dictionary mode. But I think the security aspect is more important. 

<!-- Please refer to our contributing docs for any questions on submitting a pull request -->
<!-- Issues are required for both bug fixes and features. -->
Resolves #ISSUE_NUMBER

----

### Before the change?
<!-- Please describe the current behavior that you are modifying. -->

* 

### After the change?
<!-- Please describe the behavior or changes that are being added by this PR. -->

* 

### Pull request checklist
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been reviewed and added / updated if needed (for bug fixes / features)

### Does this introduce a breaking change?
<!-- If this introduces a breaking change make sure to note it here any what the impact might be -->

Please see our docs on [breaking changes](https://github.com/octokit/.github/blob/master/community/breaking_changes.md) to help!

- [ ] Yes
- [ ] No

----

